### PR TITLE
Make kval-2022/alldeles-vanlig-python forward compatible

### DIFF
--- a/2022-kval/reversing/alldeles-vanlig-python/Dockerfile
+++ b/2022-kval/reversing/alldeles-vanlig-python/Dockerfile
@@ -1,0 +1,8 @@
+FROM registry.hub.docker.com/library/python:3.8.12-slim-bullseye
+
+RUN mkdir -p /app
+WORKDIR /app
+COPY challenge.py .
+
+CMD ["python3", "challenge.py"]
+

--- a/2022-kval/reversing/alldeles-vanlig-python/challenge.yml
+++ b/2022-kval/reversing/alldeles-vanlig-python/challenge.yml
@@ -11,6 +11,8 @@ flags: massor_av_skumma_lager
 
 downloadable_files:
   - challenge.py
+  - Dockerfile
+  - run.sh
 
 challenge_id: b962b23a-224f-4662-9f30-b1e7d4b854a5
 spec: 0.0.1

--- a/2022-kval/reversing/alldeles-vanlig-python/run.sh
+++ b/2022-kval/reversing/alldeles-vanlig-python/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+docker buildx build -t ssm_alldelesvanligpython .
+docker run --rm -it ssm_alldelesvanligpython:latest


### PR DESCRIPTION
Lägger till en Dockerfil och ett kör-skript så att det är lätt för folk att köra denna utmaning nu och i framtiden.